### PR TITLE
Change link to the broken example

### DIFF
--- a/src/v2/guide/transitioning-state.md
+++ b/src/v2/guide/transitioning-state.md
@@ -390,7 +390,7 @@ function generatePoints (stats) {
 </style>
 {% endraw %}
 
-См. [этот fiddle](https://jsfiddle.net/chrisvfritz/65gLu2b6/) для исходного кода.
+См. [этот fiddle](https://jsfiddle.net/termosa/65gLu2b6/81/) для исходного кода.
 
 ## Представление переходов как компонентов
 


### PR DESCRIPTION
Change link to JsFiddle that was directed to the broken example with the new link to the fixed example