### PR TITLE
Исправил старые ссылки

### DIFF
--- a/src/v2/guide/unit-testing.md
+++ b/src/v2/guide/unit-testing.md
@@ -6,7 +6,7 @@ order: 23
 
 ## Выбор инструментов и предварительная настройка
 
-В целом, сгодится любой инструментарий, совместимый с модульными системами сборки, но если вы ищете готовый рецепт, советуем вам использовать тестраннер [Karma](http://karma-runner.github.io). Для него создано много плагинов, включая обеспечивающие поддержку [Webpack](https://github.com/webpack/karma-webpack) и [Browserify](https://github.com/Nikku/karma-browserify). Для детального руководства, пожалуйста обратитесь к документации соответствующего проекта, а вот эти примеры конфигурации Karma для [Webpack](https://github.com/vuejs/vue-loader-example/blob/master/build/karma.conf.js) и [Browserify](https://github.com/vuejs/vueify-example/blob/master/karma.conf.js) могут помочь вам начать.
+В целом, сгодится любой инструментарий, совместимый с модульными системами сборки, но если вы ищете готовый рецепт, советуем вам использовать тестраннер [Karma](http://karma-runner.github.io). Для него создано много плагинов, включая обеспечивающие поддержку [Webpack](https://github.com/webpack/karma-webpack) и [Browserify](https://github.com/Nikku/karma-browserify). Для детального руководства, пожалуйста обратитесь к документации соответствующего проекта, а вот эти примеры конфигурации Karma для [Webpack](https://github.com/vuejs-templates/webpack/blob/master/template/test/unit/karma.conf.js) и [Browserify](https://github.com/vuejs-templates/browserify/blob/master/template/karma.conf.js) могут помочь вам начать.
 
 ## Простые операторы контроля
 


### PR DESCRIPTION
В файле src/v2/guide/unit-testing.md, на 9 строке (по исходникам), остались старые ссылки на примеры конфигураций для Webpack и Browserify. Обновил их в соответсвии с основной документацией.