### PR TITLE
page.js: замена "Github" на "GitHub"

### DIFF
--- a/themes/vue/layout/page.ejs
+++ b/themes/vue/layout/page.ejs
@@ -42,7 +42,7 @@
       <%_ } _%>
       Обнаружили ошибку или хотите добавить что-то своё в документацию?
       <a href="https://github.com/translation-gang/ru.vuejs.org/blob/master/src/<%- page.path.replace(/\.html$/, '.md') %>" target="_blank">
-        Отредактируйте эту страницу на Github!
+        Отредактируйте эту страницу на GitHub!
       </a>
     </div>
 </div>


### PR DESCRIPTION
Обновление в соответствии https://github.com/vuejs/vuejs.org/pull/1399