### PR TITLE
language_dropdown.ejs: локализация пункта меню

### DIFF
--- a/themes/vue/layout/partials/language_dropdown.ejs
+++ b/themes/vue/layout/partials/language_dropdown.ejs
@@ -1,5 +1,5 @@
 <li class="nav-dropdown-container language">
-  <a class="nav-link">Translations</a><span class="arrow"></span>
+  <a class="nav-link">Переводы</a><span class="arrow"></span>
   <ul class="nav-dropdown">
     <li><a href="https://vuejs.org/<%- page.path %>" class="nav-link" target="_blank">English</a></li>
     <li><a href="https://cn.vuejs.org/<%- page.path %>" class="nav-link" target="_blank">中文</a></li>


### PR DESCRIPTION
Не очень понимаю, почему этот пункт меню не переведён, т.е. это явно было сделано намеренно, но не непонятно зачем, в других переводах он переведён, поэтому в русской редакции тоже лучше его перевести?