### PR TITLE
Update transitioning-state.md

### DIFF
--- a/src/v2/guide/transitioning-state.md
+++ b/src/v2/guide/transitioning-state.md
@@ -515,8 +515,8 @@ Vue.component('animated-integer', {
 
       new TWEEN.Tween({ tweeningValue: startValue })
         .to({ tweeningValue: endValue }, 500)
-        .onUpdate(function (object) {
-          vm.tweeningValue = object.tweeningValue.toFixed(0)
+        .onUpdate(function () {
+          vm.tweeningValue = this.tweeningValue.toFixed(0)
         })
         .start()
 


### PR DESCRIPTION
Move fix for Tween.onUpdate from en version.
Without it all Tween examples don't work.