### PR TITLE
Восстановление нерабочих ссылок на документацию Vue Test Utils

### DIFF
--- a/src/v2/cookbook/unit-testing-vue-components.md
+++ b/src/v2/cookbook/unit-testing-vue-components.md
@@ -82,7 +82,7 @@ Automated testing allows large teams of developers to maintain complex codebases
 
 #### Getting started
 
-[Vue Test Utils](https://github.com/vuejs/vue-test-utils) is the official library for unit testing Vue components. The [vue-cli](https://github.com/vuejs/vue-cli) `webpack` template comes with either Karma or Jest, both well supported test runners, and there are some [guides](https://vue-test-utils.vuejs.org/en/guides/) in the Vue Test Utils documentation.
+[Vue Test Utils](https://github.com/vuejs/vue-test-utils) is the official library for unit testing Vue components. The [vue-cli](https://github.com/vuejs/vue-cli) `webpack` template comes with either Karma or Jest, both well supported test runners, and there are some [guides](https://vue-test-utils.vuejs.org/guides/) in the Vue Test Utils documentation.
 
 ## Real-World Example
 
@@ -231,7 +231,7 @@ The above test is fairly simple, but in practice Vue components often have other
 - committing or dispatching mutations or actions with a `Vuex` store
 - testing interaction
 
-There are more complete examples showing such tests in the Vue Test Utils [guides](https://vue-test-utils.vuejs.org/en/guides/).
+There are more complete examples showing such tests in the Vue Test Utils [guides](https://vue-test-utils.vuejs.org/guides/).
 
 Vue Test Utils and the enormous JavaScript ecosystem provides plenty of tooling to facilitate almost 100% test coverage. Unit tests are only one part of the testing pyramid, though. Some other types of tests include e2e (end to end) tests, and snapshot tests. Unit tests are the smallest and most simple of tests - they make assertions on the smallest units of work, isolating each part of a single component.
 

--- a/src/v2/guide/unit-testing.md
+++ b/src/v2/guide/unit-testing.md
@@ -131,4 +131,4 @@ it('updates the rendered message when vm.message updates', done => {
 
 Мы планируем создать набор вспомогательных функций для дальнейшего облегчения тестирования рендеринга компонентов с определёнными ограничениями (например, для поверхностного рендеринга, игнорирующего дочерние компоненты) и оценки его результатов.
 
-Подробнее о модульном тестировании во Vue, вы можете изучить на [vue-test-utils](https://vue-test-utils.vuejs.org/ru/) и на странице нашей книги рецептов [о модульном тестировании компонентов Vue](https://ru.vuejs.org/v2/cookbook/unit-testing-vue-components.html).
+Подробнее о модульном тестировании во Vue, вы можете изучить на [vue-test-utils](https://vue-test-utils.vuejs.org/) и на странице нашей книги рецептов [о модульном тестировании компонентов Vue](https://ru.vuejs.org/v2/cookbook/unit-testing-vue-components.html).


### PR DESCRIPTION
См. https://github.com/vuejs/vuejs.org/commit/9e977cdc7c629115bde6af01bb38c74607f0b3cc

ПЫСЫ почему https://vue-test-utils.vuejs.org/ru/ обновился инструмент так, что нужен новый перевод?